### PR TITLE
Trailing space after `function` should not be required

### DIFF
--- a/JavaScript.tmLanguage
+++ b/JavaScript.tmLanguage
@@ -257,7 +257,7 @@
 			<key>comment</key>
 			<string>match regular function like: function myFunc(arg) { … }</string>
 			<key>match</key>
-			<string>\b(function)\s+([a-zA-Z_$]\w*)?\s*(\()(.*?)(\))</string>
+			<string>\b(function)\s*([a-zA-Z_$]\w*)?\s*(\()(.*?)(\))</string>
 			<key>name</key>
 			<string>meta.function.js</string>
 		</dict>


### PR DESCRIPTION
In my opinion, a language definition should not be opinionated about code style, so this change allows for correct highlighting of `function ()` and `function()`. All other instances in the language definition already did it this way - with the space being "0 or more" instead of "1 or more".
